### PR TITLE
Replace CC with CXX in Makefile

### DIFF
--- a/cbits/Makefile
+++ b/cbits/Makefile
@@ -29,4 +29,4 @@ dxz_queens: dxz_queens.o dxz.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o dxz_queens $^ $(LDLIBS)
 
 %.o: %.cpp
-	$(CC) $(CXXFLAGS) -c $<
+	$(CXX) $(CXXFLAGS) -c $<


### PR DESCRIPTION
Running `make` doesn't work on my machine (CC resolves to clang which then complains).
This PR fixes it. I'm guessing this was a typo but not sure.