### PR TITLE
Add infixr 5 declaration to Thrist((:.))

### DIFF
--- a/src/Aligned/Internal.hs
+++ b/src/Aligned/Internal.hs
@@ -136,6 +136,8 @@ data Thrist f a b where
   Id   :: Thrist f a a
   (:.) :: f b c -> !(Thrist f a b) -> Thrist f a c
 
+infixr 5 :.
+
 instance a ~ b => Default (Thrist f a b) where
   def = Id
 


### PR DESCRIPTION
By analogy with []

This makes pattern-matching on multiple elements of a thrist easier