### PR TITLE
Extend MonadLogic and add alternative LogicT implementation

### DIFF
--- a/guanxi.cabal
+++ b/guanxi.cabal
@@ -89,6 +89,7 @@ library
     Log
     Logic.Class
     Logic.Cont
+    Logic.ContUnwind
     Logic.Naive
     Logic.Reflection
     Par.Cont

--- a/guanxi.cabal
+++ b/guanxi.cabal
@@ -147,6 +147,7 @@ test-suite spec
     Spec.FD.Monad
     Spec.Logic.Reflection
     Spec.Prompt.Iterator
+    Spec.Ref
     Spec.Unaligned.Base
   build-depends:
     hspec >= 2 && < 3

--- a/guanxi.cabal
+++ b/guanxi.cabal
@@ -64,7 +64,6 @@ library
     contravariant,
     fingertree,
     groups              >= 0.4 && < 0.5,
-    ghc-prim,
     hashable,
     lens,
     primitive,

--- a/src/FD/Monad.hs
+++ b/src/FD/Monad.hs
@@ -41,7 +41,7 @@ newtype FD s a = FD { runFD :: Cont.Par (FD' s) a } deriving
   )
 
 instance MonadLogic (FD s) where
-  msplit (FD m) = FD $ fmap FD <$> msplit m
+  msplit (FD m) = FD $ mapViewWithCleanup FD <$> msplit m
   interleave = (<|>)
 
 unFD :: FD s a -> LogicT (ST s) a

--- a/src/Logic/Cont.hs
+++ b/src/Logic/Cont.hs
@@ -75,7 +75,7 @@ instance MonadIO m => MonadIO (LogicT m) where
 
 instance Monad m => MonadLogic (LogicT m) where
   msplit m = lift $ runLogicT m ssk (return Empty)
-    where ssk a fk = return $ a :&: (lift fk >>= reflect)
+    where ssk a fk = return $ a :&&: pure () :&: (lift fk >>= reflect)
 
 instance (Monad m, Foldable m) => Foldable (LogicT m) where
   foldMap f m = fold $ runLogicT m (fmap . mappend . f) (return mempty)
@@ -124,5 +124,5 @@ observeManyT n m
   | n == 1 = runLogicT m (\a _ -> return [a]) (return [])
   | otherwise = runLogicT (msplit m) sk (return []) where
     sk Empty _ = return []
-    sk (a :&: m') _ = (a :) `liftM` observeManyT (n - 1) m'
+    sk (a :&&: m_bk :&: m') _ = (a :) `liftM` observeManyT (n - 1) (m_bk *> m')
 

--- a/src/Logic/ContUnwind.hs
+++ b/src/Logic/ContUnwind.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Logic.ContUnwind where
+
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Error.Class
+import Control.Monad.Fail as Fail
+import Control.Monad.Primitive
+import Control.Monad.Reader
+import Control.Monad.State.Class
+import Control.Monad.Writer.Class
+
+import Data.Foldable (fold)
+import Data.Functor.Identity
+import Data.Kind (Type)
+
+import Logic.Class
+
+import Unaligned.Base
+
+-- | A variant on 'Logic.Cont.LogicT' that maintains a distinction between the
+-- failure continuation and a monadic effect that must be executed when
+-- backtracking.  In particular, this means that 'once' can discard the local
+-- failure continuation without also making it impossible to backtrack.
+type LogicT :: (Type -> Type) -> Type -> Type
+newtype LogicT m a = LogicT
+  { runLogicTWithUnwind :: forall r. (a -> m () -> m r -> m r) -> m () -> m r -> m r
+  }
+
+runLogicT :: Applicative m => LogicT m a -> (a -> m r -> m r) -> m r -> m r
+runLogicT m sk fk = runLogicTWithUnwind m (\ a bk fk' -> sk a (bk *> fk')) (pure ()) fk
+
+type Logic = LogicT Identity
+
+runLogic :: Logic a -> forall r. (a -> r -> r) -> r -> r
+runLogic l s f = runIdentity $ runLogicT l (fmap . s) (Identity f)
+
+pattern Logic :: (forall r . (a -> r -> r) -> r -> r) -> Logic a
+pattern Logic f <- (runLogic -> f)
+  where Logic f = LogicT $ \ k _ -> Identity . f (\ a -> runIdentity . k a (Identity ()) . Identity) . runIdentity
+
+instance Functor (LogicT f) where
+  fmap f lt = LogicT $ \sk bk fk -> runLogicTWithUnwind lt (sk . f) bk fk
+
+instance Applicative (LogicT f) where
+  pure a = LogicT $ \sk bk fk -> sk a bk fk
+  f <*> a =
+    LogicT $ \sk bk fk -> runLogicTWithUnwind f (\g bk' fk' -> runLogicTWithUnwind a (sk . g) bk' fk') bk fk
+
+instance Applicative f => Alternative (LogicT f) where
+  empty = LogicT $ \ _ bk fk -> bk *> fk
+  f1 <|> f2 = LogicT $ \sk bk fk -> runLogicTWithUnwind f1 sk (pure ()) (runLogicTWithUnwind f2 sk bk fk)
+  -- The choice of backtracking continuations is subtle here   ^^^^^^^                 and here    ^^
+  -- The point is that the incoming bk represents the effects that need to be
+  -- executed if (f1 <|> f2) as a whole fails and needs to backtrack to an
+  -- earlier choice point. Thus if f1 fails, we only backtrack as far as the
+  -- choice point created by the call to <|>, so we try f2 without executing bk.
+  -- If f2 fails as well, we then need to execute bk and backtrack further.
+
+instance Monad (LogicT m) where
+  return = pure
+  m >>= f = LogicT $ \sk bk fk -> runLogicTWithUnwind m (\a bk' fk' -> runLogicTWithUnwind (f a) sk bk' fk') bk fk
+#if __GLASGOW_HASKELL__ < 808
+  fail _ = empty
+#endif
+
+instance Applicative m => MonadFail (LogicT m) where
+  fail _ = empty
+
+instance Applicative m => MonadPlus (LogicT m) where
+  mzero = empty
+  mplus = (<|>)
+
+instance MonadTrans LogicT where
+  lift m = LogicT $ \sk bk fk -> m >>= \a -> sk a bk fk
+
+instance MonadIO m => MonadIO (LogicT m) where
+  liftIO = lift . liftIO
+
+instance Monad m => MonadLogic (LogicT m) where
+
+  -- TODO: this definition could do with better justification.  In particular it
+  -- is not wholly clear what should happen if the cleanup continuation itself
+  -- backtracks.  Morally the cleanup continuation should only execute effects
+  -- in the underlying monad, but we can't express that easily.
+  pureWithCleanup (a :&&: bk) = LogicT $ \ sk bk' fk ->
+      sk a (runLogicTWithUnwind bk (\ _ bk'' _ -> bk'') (pure ()) (pure ()) >> bk') fk
+
+  cleanup v m = pureWithCleanup (() :&&: m) *> v -- TODO: really?
+
+  msplit :: forall a. LogicT m a -> LogicT m (ViewWithCleanup a (LogicT m))
+  msplit m = lift $ runLogicTWithUnwind m ssk (return ()) (return Empty)
+    where
+      ssk :: a -> m () -> m (ViewWithCleanup a (LogicT m)) -> m (ViewWithCleanup a (LogicT m))
+      ssk a bk fk = return $ a :&&: lift bk :&: (lift fk >>= reflect)
+
+instance (Monad m, Foldable m) => Foldable (LogicT m) where
+  foldMap f m = fold $ runLogicT m (fmap . mappend . f) (return mempty)
+
+instance Traversable (LogicT Identity) where
+  traverse g l = runLogic l (\a ft -> c <$> g a <*> ft) (pure mzero)
+    where c a l' = return a `mplus` l'
+
+instance MonadReader r m => MonadReader r (LogicT m) where
+  ask = lift ask
+  local f m = LogicT $ \sk bk fk -> runLogicTWithUnwind m (\a bk' fk' -> local f (sk a bk' fk')) (local f bk) (local f fk)
+
+instance MonadWriter w m => MonadWriter w (LogicT m) where
+  tell = lift . tell
+  pass = error "TODO: MonadWriter w (LogicT m) pass"
+  listen = error "TODO: MonadWriter w (LogicT m) listen"
+
+instance MonadState s m => MonadState s (LogicT m) where
+  get = lift get
+  put = lift . put
+
+-- TODO: this instance typechecks but is not obviously correct.  The use of
+-- 'handle' in two places with the same continuations is rather suspicious.
+-- instance MonadError e m => MonadError e (LogicT m) where
+--   throwError = lift . throwError
+--   catchError m h =
+--     LogicT $ \sk bk fk ->
+--       let handle r = r `catchError` \e -> runLogicTWithUnwind (h e) sk bk fk
+--        in handle $ runLogicTWithUnwind m (\a bk' -> sk a bk' . handle) bk fk -- TODO: which bk here?
+
+instance PrimMonad m => PrimMonad (LogicT m) where
+  type PrimState (LogicT m) = PrimState m
+  primitive f = lift (primitive f)
+
+observe :: Logic a -> a
+observe lt = runIdentity $ runLogicT lt (const . return) (error "No answer.")
+
+observeAll :: Logic a -> [a]
+observeAll = runIdentity . observeAllT
+
+observeT :: MonadFail m => LogicT m a -> m a
+observeT lt = runLogicT lt (const . return) (Fail.fail "No answer.")
+
+observeAllT :: Monad m => LogicT m a -> m [a]
+observeAllT m = runLogicT m (fmap . (:)) (return [])

--- a/src/Logic/Naive.hs
+++ b/src/Logic/Naive.hs
@@ -64,3 +64,11 @@ instance Monad m => MonadLogic (LogicT m) where
 instance PrimMonad m => PrimMonad (LogicT m) where
   type PrimState (LogicT m) = PrimState m
   primitive f = lift (primitive f)
+
+
+observeAllT :: Monad m => LogicT m a -> m [a]
+observeAllT m = do
+    v <- runLogicT m
+    case v of
+      h :&: t -> (:) h <$> observeAllT t
+      Empty   -> pure []

--- a/src/Logic/Naive.hs
+++ b/src/Logic/Naive.hs
@@ -59,7 +59,7 @@ instance MonadTrans LogicT where
   lift m = LogicT (m >>= single)
 
 instance Monad m => MonadLogic (LogicT m) where
-  msplit (LogicT m) = lift m
+  msplit (LogicT m) = first noCleanup <$> lift m
 
 instance PrimMonad m => PrimMonad (LogicT m) where
   type PrimState (LogicT m) = PrimState m

--- a/src/Logic/Reflection.hs
+++ b/src/Logic/Reflection.hs
@@ -109,7 +109,7 @@ instance MonadIO m => MonadIO (LogicT m) where
   liftIO = lift . liftIO
 
 instance Monad m => MonadLogic (LogicT m) where
-  msplit = lift . view
+  msplit = lift . fmap (first noCleanup) . view
 
 instance PrimMonad m => PrimMonad (LogicT m) where
   type PrimState (LogicT m) = PrimState m

--- a/src/Par/Cont.hs
+++ b/src/Par/Cont.hs
@@ -101,7 +101,7 @@ instance
   ( MonadRef m
   , MonadLogic m
   ) => MonadLogic (Par m) where
-  msplit m = fmap parState <$> parState (msplit (statePar m))
+  msplit m = mapViewWithCleanup parState <$> parState (msplit (statePar m))
 
 apply :: (a -> b, a) -> b
 apply (f,x) = f x

--- a/src/Prompt/Reflection.hs
+++ b/src/Prompt/Reflection.hs
@@ -106,7 +106,7 @@ instance MonadTrans CC where
   {-# inlineable lift #-}
 
 instance PrimMonad m => MonadCont (CC m) where
-  callCC = callcc
+  callCC f = callcc (\x -> f x)
   {-# inline callCC #-}
 
 instance PrimMonad m => MonadPrompt (CC m) where

--- a/src/SAT.hs
+++ b/src/SAT.hs
@@ -13,6 +13,7 @@ import Control.Monad.Primitive
 import Data.Bits
 import Data.Primitive.Types
 import Data.Word
+import Logic.Class
 import Vec
 
 newtype Val = Val Word8
@@ -71,7 +72,7 @@ type GivenSAT s = (?sat :: SAT s)
 
 newtype Var s = Var Int
 
-type MonadSAT m = (PrimMonad m, MonadPlus m, GivenSAT (PrimState m))
+type MonadSAT m = (PrimMonad m, MonadLogic m, GivenSAT (PrimState m))
 type ReadMonadSAT m = (PrimMonad m, GivenSAT (PrimState m))
 
 newVar :: MonadSAT m => m (Var (PrimState m))

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -16,8 +16,7 @@ module Unique
 
 import Control.Monad.Primitive
 import Data.Hashable
-import GHC.Prim
-import GHC.Types
+import GHC.Exts
 
 data Unique s = Unique !Int (MutableByteArray# s)
 type UniqueM m = Unique (PrimState m)

--- a/test/Spec/Ref.hs
+++ b/test/Spec/Ref.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Spec.Ref where
+
+import Control.Applicative (Alternative (empty, (<|>)))
+import Control.Monad
+
+import Logic.Class
+import qualified Logic.Cont as Cont
+import qualified Logic.Naive as Naive
+import qualified Logic.Reflection as Reflection
+
+import Ref (MonadRef, newRef, readRef, writeRef)
+
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = do
+  specFor "Cont"       Cont.observeAllT
+  specFor "Naive"      Naive.observeAllT
+  specFor "Reflection" Reflection.observeAllT
+
+specFor :: (MonadLogic m, MonadRef m) => String -> (forall a. m a -> IO [a]) -> Spec
+specFor s observeAllT = describe s $ do
+  describe "writeRef" $ do
+    it "backtracks a write followed by success" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (writeRef x 2 >> pure 2) <|> (readRef x)
+        rs `shouldBe` [2, 1]
+
+    it "backtracks a write followed by failure" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (writeRef x 2 >> empty) <|> (readRef x)
+        rs `shouldBe` [1]
+
+    it "backtracks a write followed by a choice" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            writeRef x 2
+            (readRef x <|> readRef x)
+        rs `shouldBe` [2,2]
+
+
+  describe "once" $ do
+    -- The following is debatable behaviour, but captures the current
+    -- interaction between once and writeRef.  The issue is that once discards
+    -- the failure continuation, but writeRef relies on the failure continuation
+    -- being called in order to unwind the write.  Thus in this test case, the
+    -- write is visible in both alternatives.
+    --
+    -- Prolog has cut (!) which is rather similar to once, in that it discards
+    -- relevant choice points. However, Prolog implementations maintain separate
+    -- representations of the choice point stack (like '<|>') and the trail (the
+    -- addresses of references that have been written).  Thus even when cut is
+    -- used to discard choice points, the trail can still be used to correctly
+    -- revert writes when backtracking to an earlier choice point.
+    --
+    it "backtracks a write under once if it succeeds" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (once (writeRef x 2 >> pure 2)) <|> (readRef x)
+        rs `shouldBe` [2,1] `butIs` [2,2]
+
+    -- Within the local scope of a call to once, backtracking happens normally,
+    -- so if the computation under once fails then the write ends up being
+    -- backtracked as we would expect.
+    it "backtracks a write-failure under once" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (once (writeRef x 2 >> empty)) <|> (readRef x)
+        rs `shouldBe` [1]
+
+    -- Here the computation under once succeeds so the unwind continuation is
+    -- discarded before the failure. Thus the write is not backtracked.
+    it "backtracks a write under once if failure happens later" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (once (writeRef x 2) >> empty) <|> (readRef x)
+        rs `shouldBe` [1] `butIs` [2]
+
+    -- Here the write under once cannot be backtracked, but the preceding write
+    -- can be backtracked, so (somewhat counterintuitively) the read sees the
+    -- original value of the reference.
+    it "backtracks a write before once" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (writeRef x 3 >> once (writeRef x 2) >> empty) <|> (readRef x)
+        rs `shouldBe` [1]
+
+    it "does not backtrack two writes under once" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (once (writeRef x 2 <|> writeRef x 3) >> pure 0) <|> (readRef x)
+        rs `shouldBe` [0,1] `butIs` [0,2]
+
+    it "executes two writes" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            writeRef x 2 <|> writeRef x 3
+            readRef x
+        rs `shouldBe` [2,3]
+
+    it "executes a write once" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            once (writeRef x 2 <|> writeRef x 3)
+            readRef x
+        rs `shouldBe` [2]
+
+
+  describe "lnot" $ do
+    it "backtracks a write under lnot" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (lnot (writeRef x 2) >> readRef x) <|> (readRef x)
+        rs `shouldBe` [1] `butIs` [2]
+
+    it "backtracks a write followed by failure under lnot" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (lnot (writeRef x 2 >> empty) >> readRef x) <|> (readRef x)
+        rs `shouldBe` [1,1]
+
+    it "backtracks a write under lnot . lnot" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (lnot (lnot (writeRef x 2)) >> readRef x) <|> (readRef x)
+        rs `shouldBe` [1,1] `butIs` [2,2]
+
+    it "backtracks both of two writes under lnot" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (lnot (writeRef x 2 <|> writeRef x 3) >> readRef x) <|> (readRef x)
+        rs `shouldBe` [1] `butIs` [2]
+
+    it "backtracks both of two writes under lnot . lnot" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (lnot (lnot (writeRef x 2 <|> writeRef x 3)) >> readRef x) <|> (readRef x)
+        rs `shouldBe` [1,1] `butIs` [2,2]
+
+
+  describe "ifte" $ do
+    it "backtracks a write under ifte" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (ifte (writeRef x 2) (const (readRef x)) undefined) <|> (readRef x)
+        rs `shouldBe` [2,1]
+
+    it "backtracks a write when ifte fails" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (ifte (writeRef x 2 *> empty) undefined (readRef x)) <|> (readRef x)
+        rs `shouldBe` [1,1]
+
+    it "backtracks a write under once . ifte" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (once (ifte (writeRef x 2) (const (readRef x)) undefined)) <|> (readRef x)
+        rs `shouldBe` [2,1] `butIs` [2,2]
+
+
+  describe "msplit" $ do
+    it "msplit >=> reflect is the identity" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (msplit >=> reflect) ((writeRef x 2 *> readRef x) <|> readRef x) <|> readRef x
+        rs `shouldBe` [2,1,1]
+
+    it "msplit >=> reflect cleans up" $ do
+        rs <- observeAllT $ do
+            x <- newRef (1 :: Int)
+            (msplit >=> reflect) (readRef x <|> (writeRef x 2 >> readRef x)) <|> readRef x
+        rs `shouldBe` [1,2,1]
+  where
+    -- The first argument is the "correct" result while
+    -- the second is the result actually yielded by the implementation.
+    butIs :: a -> a -> a
+    butIs = const
+    infix 5 `butIs`

--- a/test/Spec/Ref.hs
+++ b/test/Spec/Ref.hs
@@ -8,6 +8,7 @@ import Control.Monad
 
 import Logic.Class
 import qualified Logic.Cont as Cont
+import qualified Logic.ContUnwind as ContUnwind
 import qualified Logic.Naive as Naive
 import qualified Logic.Reflection as Reflection
 
@@ -18,6 +19,7 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 spec :: Spec
 spec = do
   specFor "Cont"       Cont.observeAllT
+  specFor "ContUnwind" ContUnwind.observeAllT
   specFor "Naive"      Naive.observeAllT
   specFor "Reflection" Reflection.observeAllT
 

--- a/test/spec.hs
+++ b/test/spec.hs
@@ -8,6 +8,7 @@ import qualified Spec.FD.Monad
 import qualified Spec.Domain.Interval
 import qualified Spec.Prompt.Iterator
 import qualified Spec.Logic.Reflection
+import qualified Spec.Ref
 import qualified Spec.Unaligned.Base
 
 main :: IO ()
@@ -17,4 +18,5 @@ main = hspecWith defaultConfig {configFormatter = Just progress} $ do
   Spec.FD.Monad.spec
   Spec.Logic.Reflection.spec
   Spec.Prompt.Iterator.spec
+  Spec.Ref.spec
   Spec.Unaligned.Base.spec


### PR DESCRIPTION
This builds on #23 to solve the problem described in #22:
 * We modify the `MonadLogic` interface to maintain a distinction between alternatives and "cleanup operations" that need to be called when backtracking. In particular, a new `pureWithCleanup` method makes it possible to return a result and register a cleanup operation associated with it, and the type of `msplit` changes to make it possible to reify both continuations.
 *  `unwind` now calls `pureWithCleanup`.
 * A new `LogicT` implementation in the `Logic.ContUnwind` module implements the intended semantics for the extended `MonadLogic` interface, by adapting the `Logic.Cont` implementation to use an extra continuation.
 * As a result, the `Spec.Ref` tests introduced in #23 pass for this implementation (only).

Feedback on whether this is the correct solution strategy would be very welcome.

cc @np