### PR TITLE
patches for ghc-9.10.1 as a build compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: haskell ci
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.7.0
+        with:
+          cabal-file: guanxi.cabal
+          ubuntu-version: latest
+          macos-version: latest
+          windows-version: latest
+          version: 0.1.7.0
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - run: cabal freeze --enable-tests
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal build all
+      - run: cabal test --test-option=--color --test-show-details=always test:queens
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      - run: cabal test --test-option=--color --test-show-details=always test:spec
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      - run: cabal test --test-option=--color --test-show-details=always test:hedgehog
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 guanxi
 ======
 
-[![Travis Continuous Integration Status][travis-img]][travis]
+[![haskell ci](https://github.com/ekmett/guanxi/actions/workflows/ci.yml/badge.svg)](https://github.com/ekmett/guanxi/actions/workflows/ci.yml)
 
 An exploration of relational programming in Haskell.
 
@@ -34,5 +34,3 @@ Please feel free to contact me through github or on the `#haskell` IRC channel o
 
  [license-apache]: http://www.apache.org/licenses/LICENSE-2.0
  [license-bsd]: https://opensource.org/licenses/BSD-2-Clause
- [travis]: http://travis-ci.org/ekmett/guanxi
- [travis-img]: https://secure.travis-ci.org/ekmett/guanxi.png?branch=master

--- a/guanxi.cabal
+++ b/guanxi.cabal
@@ -13,6 +13,7 @@ copyright:     Copyright (C) 2018 Edward A. Kmett
 synopsis:      Relational programming
 description:   Propagator-based relational programming in Haskell.
 build-type:    Simple
+tested-with: GHC == 9.10.1
 extra-source-files:
   .hlint.yaml
   CHANGELOG.md
@@ -41,7 +42,7 @@ common data-default
   build-depends: data-default
 
 common mtl
-  build-depends: mtl >= 2.2.2 && < 2.3
+  build-depends: mtl >= 2.2.2 && < 3
 
 common primitive
   build-depends: primitive
@@ -68,7 +69,7 @@ library
     hashable,
     lens,
     primitive,
-    transformers        >= 0.5.5 && < 0.6,
+    transformers        >= 0.5.5 && < 0.7,
     unordered-containers
 
   exposed-modules:
@@ -136,7 +137,7 @@ test-suite hedgehog
   type: exitcode-stdio-1.0
   main-is: hedgehog-main.hs
   build-depends:
-    hedgehog >= 0.6.1 && < 1.1
+    hedgehog >= 0.6.1 && < 2
 
 test-suite spec
   import: test, mtl, primitive

--- a/src/FD/Monad.hs
+++ b/src/FD/Monad.hs
@@ -19,6 +19,7 @@
 module FD.Monad where
 
 import Control.Applicative
+import Control.Monad (MonadPlus)
 import Control.Monad.Primitive
 import Control.Monad.Reader
 import Control.Monad.State.Strict

--- a/src/Logic/Cont.hs
+++ b/src/Logic/Cont.hs
@@ -112,8 +112,8 @@ observeAll = runIdentity . observeAllT
 observeMany :: Int -> Logic a -> [a]
 observeMany i = runIdentity . observeManyT i
 
-observeT :: MonadFail m => LogicT m a -> m a
-observeT lt = runLogicT lt (const . return) (Fail.fail "No answer.")
+observeT :: Monad m => LogicT m a -> m a
+observeT lt = runLogicT lt (const . return) (error "No answer.")
 
 observeAllT :: Monad m => LogicT m a -> m [a]
 observeAllT m = runLogicT m (fmap . (:)) (return [])
@@ -125,4 +125,3 @@ observeManyT n m
   | otherwise = runLogicT (msplit m) sk (return []) where
     sk Empty _ = return []
     sk (a :&: m') _ = (a :) `liftM` observeManyT (n - 1) m'
-

--- a/src/Relative/Internal.hs
+++ b/src/Relative/Internal.hs
@@ -31,7 +31,7 @@ module Relative.Internal
 import Data.Default
 import Data.Group
 import Data.Semigroup (Semigroup(stimes))
-import GHC.Exts as Exts
+import GHC.Exts as Exts hiding(One)
 import Unaligned.Internal (View(..), Rev(..))
 
 --------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ instance Abelian Unit
 
 data Aff = Aff !Unit !Integer
 
--- group action 
+-- group action
 utimes :: Unit -> Integer -> Integer
 utimes One = id
 utimes NegativeOne = negate
@@ -178,7 +178,7 @@ instance Default (Q a) where
   def = Q mempty [] (Rev []) []
 
 instance (Show a, Relative a) => Show (Q a) where
-  showsPrec d = showsPrec d . Exts.toList 
+  showsPrec d = showsPrec d . Exts.toList
 
 instance Relative a => IsList (Q a) where
   type Item (Q a) = a
@@ -226,11 +226,11 @@ instance Relative a => Relative (Cat a) where
   rel (Aff One 0) as = as
   rel d (C a as) = C (rel d a) (rel d as)
 
-instance Relative a => RelativeSemigroup (Cat a) 
-instance Relative a => RelativeMonoid (Cat a) 
-  
+instance Relative a => RelativeSemigroup (Cat a)
+instance Relative a => RelativeMonoid (Cat a)
+
 instance (Relative a, Show a) => Show (Cat a) where
-  showsPrec d = showsPrec d . Exts.toList 
+  showsPrec d = showsPrec d . Exts.toList
 
 foldMapCat :: (Relative a, Monoid m) => (a -> m) -> Cat a -> m
 foldMapCat _ E = mempty

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -16,14 +16,14 @@ module Unique
 
 import Control.Monad.Primitive
 import Data.Hashable
-import GHC.Prim
+import GHC.Exts
 import GHC.Types
 
 data Unique s = Unique !Int (MutableByteArray# s)
 type UniqueM m = Unique (PrimState m)
 
 instance Eq (Unique s) where
-  Unique _ p == Unique _ q = isTrue# (sameMutableByteArray# p q)
+  Unique _ p == Unique _ q = isTrue# (GHC.Exts.sameMutableByteArray# p q)
 
 instance Hashable (Unique s) where
   hash (Unique i _) = i


### PR DESCRIPTION
- enable ghc-9.10.1 as a build compiler
  - update some package bounds
  - fix some source compat issues
- add a tested-at stanza to guanxi.cabal
- add a github workflow
- update the README build status badge to refer to the workflow

see test results here https://github.com/shayne-fletcher/guanxi/actions/runs/10747922080.  excluded windows due to failures (not triaged).